### PR TITLE
Replacing cups-config with pkg-config call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unitdir 	=	`pkg-config --variable=systemdsystemunitdir systemd`
 CSFLAGS		=	-s "$${CODESIGN_IDENTITY:=-}" --timestamp -o runtime
 CFLAGS		=	$(CPPFLAGS) $(OPTIM)
 CPPFLAGS	=	'-DVERSION="$(VERSION)"' `pkg-config --cflags cups` `pkg-config --cflags pappl` $(OPTIONS)
-LDFLAGS		=	$(OPTIM) `cups-config --ldflags`
+LDFLAGS		=	$(OPTIM) `pkg-config --libs cups`
 LIBS		=	`pkg-config --libs pappl` `pkg-config --libs cups`
 OPTIM		=	-Os -g
 # Uncomment the following line to enable experimental PCL 6 support


### PR DESCRIPTION
Per issue #15 - Still a "cups-config" in Makefile